### PR TITLE
Request to get jterminal on Central.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,27 @@
   <inceptionYear>2009</inceptionYear>
   <description>JTerminal is a terminal emulator for Java's Swing GUI library.</description>
 
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>http://www.opensource.org/licenses/mit-license.php</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <scm>
+    <url>https://github.com/grahamedgecombe/jterminal</url>
+    <connection>scm:git:git://github.com/grahamedgecombe/jterminal.git/</connection>
+  </scm>
+
+  <developers>
+    <developer>
+      <id>graham</id>
+      <name>Graham Edgecombe</name>
+      <email>grahamedgecombe@gmail.com</email>
+    </developer>
+  </developers>
+
   <dependencies>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Please get jterminal onto The Central Repository.  This would help resolve jterminal as a maven dependency.

I would recommend using Sonatype's free oss hosting service.  Instructions are here:
https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide

Iv'e made some updates to the pom file that might help in this process.
