### PR TITLE
Inner border for JTerminal, and ASCII Line Feed fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 *~
 !.git*
 !.mailmap
+*.iml
 /target
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+	<version>3.0</version>
         <configuration>
           <source>1.6</source>
           <target>1.6</target>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>jterminal</artifactId>
   <packaging>jar</packaging>
 
-  <version>1.0.2-SNAPSHOT</version>
+  <version>1.0.2-loomcom-SNAPSHOT</version>
   <name>JTerminal</name>
   <url>http://grahamedgecombe.com/projects/jterminal</url>
   <inceptionYear>2009</inceptionYear>

--- a/src/main/java/com/grahamedgecombe/jterminal/JTerminal.java
+++ b/src/main/java/com/grahamedgecombe/jterminal/JTerminal.java
@@ -22,10 +22,7 @@
 
 package com.grahamedgecombe.jterminal;
 
-import java.awt.BorderLayout;
-import java.awt.Dimension;
-import java.awt.Font;
-import java.awt.Graphics;
+import java.awt.*;
 import java.awt.event.AdjustmentEvent;
 import java.awt.event.AdjustmentListener;
 
@@ -36,114 +33,15 @@ import com.grahamedgecombe.jterminal.vt100.Vt100TerminalModel;
 
 /**
  * A Swing terminal emulation component.
+ *
  * @author Graham Edgecombe
  */
 public class JTerminal extends JComponent {
 
 	/**
-	 * The component that actually draws the terminal.
-	 * @author Graham Edgecombe
+	 * Inner border width in pixels.
 	 */
-	private class Terminal extends JComponent {
-
-		/**
-		 * The cell width in pixels.
-		 */
-		private static final int CELL_WIDTH = 8;
-
-		/**
-		 * The cell height in pixels.
-		 */
-		private static final int CELL_HEIGHT = 12;
-
-		/**
-		 * Inner border width in pixels.
-		 */
-		private int borderWidth = 0;
-
-		/**
-		 * The font.
-		 */
-		private final Font font = new Font("Monospaced", Font.PLAIN, CELL_HEIGHT);
-
-		/**
-		 * The unique serial version id.
-		 */
-		private static final long serialVersionUID = 8832602559840777008L;
-
-		/**
-		 * Creates the terminal.
-		 */
-		private Terminal() {
-			setDoubleBuffered(true);
-		}
-
-		/**
-		 * @return The inner border width, in pixels.
-		 */
-		public int getBorderWidth() {
-			return borderWidth;
-		}
-
-		/**
-		 * Set the inner border width of the terminal component.
-		 * @param borderWidth The width of the border, in pixels.
-		 */
-		public void setBorderWidth(int borderWidth) {
-			this.borderWidth = borderWidth;
-			revalidate();
-		}
-
-		@Override
-		public Dimension getMinimumSize() {
-			return new Dimension(model.getColumns() * CELL_WIDTH + borderWidth * 2,
-                           model.getRows() * CELL_HEIGHT + borderWidth * 2);
-		}
-
-		@Override
-		public Dimension getMaximumSize() {
-			return getMinimumSize();
-		}
-
-		@Override
-		public Dimension getPreferredSize() {
-			return getMinimumSize();
-		}
-
-		@Override
-		public void paint(Graphics g) {
-			g.setFont(font);
-
-			int width = model.getColumns();
-			int height = model.getBufferSize();
-
-			g.setColor(model.getDefaultBackgroundColor());
-			g.fillRect(0, 0, width * CELL_WIDTH + borderWidth * 2, height * CELL_HEIGHT + borderWidth * 2);
-
-			int start = scrollBar == null ? 0 : scrollBar.getValue();
-			for (int y = start; y < height; y++) {
-				for (int x = 0; x < width; x++) {
-					TerminalCell cell = model.getCell(x, y);
-					boolean cursorHere = model.getCursorRow() == y && model.getCursorColumn() == x;
-
-					if (cursorHere && cell == null) {
-						cell = new TerminalCell(' ', model.getDefaultBackgroundColor(), model.getDefaultForegroundColor());
-					}
-
-					if (cell != null) {
-						int px = x * CELL_WIDTH + borderWidth;
-						int py = (y - start) * CELL_HEIGHT + borderWidth;
-
-						g.setColor(cursorHere ? cell.getForegroundColor() : cell.getBackgroundColor());
-						g.fillRect(px, py, CELL_WIDTH, CELL_HEIGHT);
-
-						g.setColor(cursorHere ? cell.getBackgroundColor() : cell.getForegroundColor());
-						g.drawChars(new char[] { cell.getCharacter() }, 0, 1, px, py + CELL_HEIGHT);
-					}
-				}
-			}
-		}
-	}
+	private int borderWidth = 0;
 
 	/**
 	 * The unique serial version id.
@@ -161,24 +59,177 @@ public class JTerminal extends JComponent {
 	private TerminalModel model;
 
 	/**
-	 * The current terminal component.
+	 * The font to use for this terminal.
 	 */
-	private Terminal terminal;
+	private Font font;
+
+	/**
+	 * The width of each character cell, in pixels.
+	 */
+	private int cellWidth;
+
+	/**
+	 * The height of each character cell, in pixels.
+	 */
+	private int cellHeight;
+
+	/**
+	 * The maximum descender height of a character cell, in pixels.
+	 */
+	private int maxDescender;
 
 	/**
 	 * Creates a terminal with the a new {@link Vt100TerminalModel}.
 	 */
-	public JTerminal() {
-		this(new Vt100TerminalModel());
+	public JTerminal(Font font) {
+		this(new Vt100TerminalModel(), font);
 	}
 
 	/**
 	 * Creates a terminal with the specified model.
+	 *
 	 * @param model The model.
 	 */
-	public JTerminal(TerminalModel model) {
+	public JTerminal(TerminalModel model, Font font) {
 		setModel(model);
+		setFont(font);
 		init();
+	}
+
+	/**
+	 * Set the inner border width of the terminal component.
+	 *
+	 * @param borderWidth The width of the border, in pixels.
+	 */
+	public void setBorderWidth(int borderWidth) {
+		this.borderWidth = borderWidth;
+		revalidate();
+	}
+
+	/**
+	 * @return The inner border width, in pixels.
+	 */
+	public int getBorderWidth() {
+		return borderWidth;
+	}
+
+	/**
+	 * Set the font to use for this terminal.
+	 *
+	 * Setting the font will cause the component to 
+	 * revalidate and repaint.
+	 *
+	 * @param font The font to use for this terminal.
+	 */
+	public void setFont(Font font) {
+		this.font = font;
+		setCellWidthAndHeight(font);
+		revalidate();
+	}
+
+	/**
+	 * @return the font used for this terminal
+	 */
+	public Font getFont() {
+		return font;
+	}
+
+	/**
+	 * Sets the current terminal model.
+	 *
+	 * @param model The new terminal model.
+	 * @throws NullPointerException if the model is {@code null}.
+	 */
+	public void setModel(TerminalModel model) {
+		if (model == null) {
+			throw new NullPointerException("model");
+		}
+		this.model = model;
+	}
+
+	/**
+	 * Gets the current terminal model.
+	 *
+	 * @return The current terminal model.
+	 */
+	public TerminalModel getModel() {
+		return model;
+	}
+
+	/**
+	 * Prints a line to the terminal. This method is shorthand for:
+	 * {@code getModel().print(str.concat("\r\n"));}
+	 *
+	 * @param str The string to print.
+	 * @throws NullPointerException if the string is null.
+	 */
+	public void println(String str) {
+		if (str == null) {
+			throw new NullPointerException("str");
+		}
+		print(str.concat("\r\n"));
+	}
+
+	/**
+	 * Prints a string to the terminal. This method is shorthand for:
+	 * {@code getModel().print(str);}
+	 *
+	 * @param str The string to print.
+	 * @throws NullPointerException if the string is null.
+	 */
+	public void print(String str) {
+		model.print(str);
+	}
+
+
+	@Override
+	public Dimension getMinimumSize() {
+		return new Dimension(model.getColumns() * cellWidth + borderWidth * 2,
+				model.getRows() * cellHeight + borderWidth * 2);
+	}
+
+	@Override
+	public Dimension getMaximumSize() {
+		return getMinimumSize();
+	}
+
+	@Override
+	public Dimension getPreferredSize() {
+		return getMinimumSize();
+	}
+
+	@Override
+	public void paint(Graphics g) {
+		g.setFont(font);
+
+		int width = model.getColumns();
+		int height = model.getBufferSize();
+
+		g.setColor(model.getDefaultBackgroundColor());
+		g.fillRect(0, 0, width * cellWidth + borderWidth * 2, height * cellHeight + borderWidth * 2);
+
+		int start = scrollBar == null ? 0 : scrollBar.getValue();
+		for (int y = start; y < height; y++) {
+			for (int x = 0; x < width; x++) {
+				TerminalCell cell = model.getCell(x, y);
+				boolean cursorHere = model.getCursorRow() == y && model.getCursorColumn() == x;
+
+				if (cursorHere && cell == null) {
+					cell = new TerminalCell(' ', model.getDefaultBackgroundColor(), model.getDefaultForegroundColor());
+				}
+
+				if (cell != null) {
+					int px = x * cellWidth + borderWidth;
+					int py = (y - start) * cellHeight + borderWidth;
+
+					g.setColor(cursorHere ? cell.getForegroundColor() : cell.getBackgroundColor());
+					g.fillRect(px, py, cellWidth, cellHeight);
+
+					g.setColor(cursorHere ? cell.getBackgroundColor() : cell.getForegroundColor());
+					g.drawChars(new char[]{cell.getCharacter()}, 0, 1, px, py + cellHeight - maxDescender);
+				}
+			}
+		}
 	}
 
 	/**
@@ -186,7 +237,6 @@ public class JTerminal extends JComponent {
 	 */
 	private void init() {
 		setLayout(new BorderLayout(0, 0));
-		this.terminal = new Terminal();
 
 		int rows = model.getRows();
 		int bufferSize = model.getBufferSize();
@@ -202,71 +252,14 @@ public class JTerminal extends JComponent {
 			add(BorderLayout.LINE_END, scrollBar);
 		}
 
-		add(BorderLayout.CENTER, terminal);
-
 		repaint();
 	}
 
-	/**
-	 * Gets the current terminal model.
-	 * @return The current terminal model.
-	 */
-	public TerminalModel getModel() {
-		return model;
+	private void setCellWidthAndHeight(Font font) {
+		FontMetrics metrics = getFontMetrics(font);
+		cellWidth = metrics.charWidth('W');
+		cellHeight = metrics.getHeight();
+		maxDescender = metrics.getMaxDescent();
 	}
-
-	/**
-	 * Sets the border width of the current terminal component.
-	 * @param borderWidth The width of the border, in pixels.
-	 */
-	public void setBorderWidth(int borderWidth) {
-		if (terminal != null) {
-			terminal.setBorderWidth(borderWidth);
-		}
-	}
-
-	/**
-	 * Returns the current border width of the terminal component.
-	 * @return The width of the border, in pixels.
-	 */
-	public int getBorderWidth() {
-		return terminal.getBorderWidth();
-	}
-
-	/**
-	 * Sets the current terminal model.
-	 * @param model The new terminal model.
-	 * @throws NullPointerException if the model is {@code null}.
-	 */
-	public void setModel(TerminalModel model) {
-		if (model == null) {
-			throw new NullPointerException("model");
-		}
-		this.model = model;
-	}
-
-	/**
-	 * Prints a line to the terminal. This method is shorthand for:
-	 * {@code getModel().print(str.concat("\r\n"));}
-	 * @param str The string to print.
-	 * @throws NullPointerException if the string is null.
-	 */
-	public void println(String str) {
-		if (str == null) {
-			throw new NullPointerException("str");
-		}
-		print(str.concat("\r\n"));
-	}
-
-	/**
-	 * Prints a string to the terminal. This method is shorthand for:
-	 * {@code getModel().print(str);}
-	 * @param str The string to print.
-	 * @throws NullPointerException if the string is null.
-	 */
-	public void print(String str) {
-		model.print(str);
-	}
-
 }
 

--- a/src/main/java/com/grahamedgecombe/jterminal/JTerminal.java
+++ b/src/main/java/com/grahamedgecombe/jterminal/JTerminal.java
@@ -57,6 +57,11 @@ public class JTerminal extends JComponent {
 		private static final int CELL_HEIGHT = 12;
 
 		/**
+		 * Inner border width in pixels.
+		 */
+		private int borderWidth = 0;
+
+		/**
 		 * The font.
 		 */
 		private final Font font = new Font("Monospaced", Font.PLAIN, CELL_HEIGHT);
@@ -73,9 +78,26 @@ public class JTerminal extends JComponent {
 			setDoubleBuffered(true);
 		}
 
+		/**
+		 * @return The inner border width, in pixels.
+		 */
+		public int getBorderWidth() {
+			return borderWidth;
+		}
+
+		/**
+		 * Set the inner border width of the terminal component.
+		 * @param borderWidth The width of the border, in pixels.
+		 */
+		public void setBorderWidth(int borderWidth) {
+			this.borderWidth = borderWidth;
+			revalidate();
+		}
+
 		@Override
 		public Dimension getMinimumSize() {
-			return new Dimension(model.getColumns() * CELL_WIDTH, model.getRows() * CELL_HEIGHT);
+			return new Dimension(model.getColumns() * CELL_WIDTH + borderWidth * 2,
+                           model.getRows() * CELL_HEIGHT + borderWidth * 2);
 		}
 
 		@Override
@@ -96,7 +118,7 @@ public class JTerminal extends JComponent {
 			int height = model.getBufferSize();
 
 			g.setColor(model.getDefaultBackgroundColor());
-			g.fillRect(0, 0, width * CELL_WIDTH, height * CELL_HEIGHT);
+			g.fillRect(0, 0, width * CELL_WIDTH + borderWidth * 2, height * CELL_HEIGHT + borderWidth * 2);
 
 			int start = scrollBar == null ? 0 : scrollBar.getValue();
 			for (int y = start; y < height; y++) {
@@ -109,8 +131,8 @@ public class JTerminal extends JComponent {
 					}
 
 					if (cell != null) {
-						int px = x * CELL_WIDTH;
-						int py = (y - start) * CELL_HEIGHT;
+						int px = x * CELL_WIDTH + borderWidth;
+						int py = (y - start) * CELL_HEIGHT + borderWidth;
 
 						g.setColor(cursorHere ? cell.getForegroundColor() : cell.getBackgroundColor());
 						g.fillRect(px, py, CELL_WIDTH, CELL_HEIGHT);
@@ -121,7 +143,6 @@ public class JTerminal extends JComponent {
 				}
 			}
 		}
-
 	}
 
 	/**
@@ -138,6 +159,11 @@ public class JTerminal extends JComponent {
 	 * The current model.
 	 */
 	private TerminalModel model;
+
+	/**
+	 * The current terminal component.
+	 */
+	private Terminal terminal;
 
 	/**
 	 * Creates a terminal with the a new {@link Vt100TerminalModel}.
@@ -160,6 +186,7 @@ public class JTerminal extends JComponent {
 	 */
 	private void init() {
 		setLayout(new BorderLayout(0, 0));
+		this.terminal = new Terminal();
 
 		int rows = model.getRows();
 		int bufferSize = model.getBufferSize();
@@ -175,7 +202,7 @@ public class JTerminal extends JComponent {
 			add(BorderLayout.LINE_END, scrollBar);
 		}
 
-		add(BorderLayout.CENTER, new Terminal());
+		add(BorderLayout.CENTER, terminal);
 
 		repaint();
 	}
@@ -186,6 +213,24 @@ public class JTerminal extends JComponent {
 	 */
 	public TerminalModel getModel() {
 		return model;
+	}
+
+	/**
+	 * Sets the border width of the current terminal component.
+	 * @param borderWidth The width of the border, in pixels.
+	 */
+	public void setBorderWidth(int borderWidth) {
+		if (terminal != null) {
+			terminal.setBorderWidth(borderWidth);
+		}
+	}
+
+	/**
+	 * Returns the current border width of the terminal component.
+	 * @return The width of the border, in pixels.
+	 */
+	public int getBorderWidth() {
+		return terminal.getBorderWidth();
 	}
 
 	/**

--- a/src/main/java/com/grahamedgecombe/jterminal/vt100/Vt100TerminalModel.java
+++ b/src/main/java/com/grahamedgecombe/jterminal/vt100/Vt100TerminalModel.java
@@ -210,9 +210,8 @@ public class Vt100TerminalModel extends AbstractTerminalModel {
 					cursorColumn = 0;
 					continue;
 				case '\n':
-					cursorColumn = 0;
 					cursorRow++;
-					continue;
+					break;
 				case '\t':
 					while ((++cursorColumn % TAB_WIDTH) != 0);
 					continue;
@@ -243,7 +242,9 @@ public class Vt100TerminalModel extends AbstractTerminalModel {
 
 				Color back = backgroundBold ? SgrColor.COLOR_BRIGHT[backgroundColor] : SgrColor.COLOR_NORMAL[backgroundColor];
 				Color fore = foregroundBold ? SgrColor.COLOR_BRIGHT[foregroundColor] : SgrColor.COLOR_NORMAL[foregroundColor];
-				cells[cursorRow][cursorColumn++] = new TerminalCell(ch, back, fore);
+				if (ch != '\n') {
+					cells[cursorRow][cursorColumn++] = new TerminalCell(ch, back, fore);
+				}
 			}
 		}
 

--- a/src/main/java/com/grahamedgecombe/jterminal/vt100/Vt100TerminalModel.java
+++ b/src/main/java/com/grahamedgecombe/jterminal/vt100/Vt100TerminalModel.java
@@ -215,6 +215,7 @@ public class Vt100TerminalModel extends AbstractTerminalModel {
 				case '\t':
 					while ((++cursorColumn % TAB_WIDTH) != 0);
 					continue;
+				case 8:
 				case 127:
 					if (cursorColumn > 0) {
 						cells[cursorRow][--cursorColumn] = null;

--- a/src/test/java/com/grahamedgecombe/jterminal/vt100/TestVt100TerminalModel.java
+++ b/src/test/java/com/grahamedgecombe/jterminal/vt100/TestVt100TerminalModel.java
@@ -77,7 +77,7 @@ public class TestVt100TerminalModel {
 
 		model.print("\na");
 		assertEquals('c', model.getCell(0, 0).getCharacter());
-		assertEquals('a', model.getCell(0, 1).getCharacter());
+		assertEquals('a', model.getCell(1, 1).getCharacter());
 
 		model.print("\u007F");
 		assertNull(model.getCell(0, 1));


### PR DESCRIPTION
[Edited pull request]

Hey there,

I'm using your awesome JTerminal in my 6502 simulator project "symon". I've made two small changes.
1. For readability, I wanted to add a little bit of extra blank space between the text and the component border, so I've made a change to allow setting an arbitrary inner border width. (The empty area will be the same color as the default cell background)
2. I very slightly changed handling of the Line Feed character, both to fix a small bug and to better mirror real VT100-style terminal behavior.

Thanks for your work - I looked high and low for a good generic VT100 style terminal that I could use as a drop-in component, and yours was by far the best and easiest to use.
